### PR TITLE
allow omitting localMaterial in conversions

### DIFF
--- a/src/main/java/world/bentobox/greenhouses/managers/RecipeManager.java
+++ b/src/main/java/world/bentobox/greenhouses/managers/RecipeManager.java
@@ -165,7 +165,12 @@ public class RecipeManager {
                         String[] split = conversions.split(":");
                         int convChance = Integer.parseInt(split[0]);
                         Material newMaterial = Material.valueOf(split[1]);
-                        Material localMaterial = Material.valueOf(split[2]);
+                        Material localMaterial;
+                        if (split.length > 2) {
+                            localMaterial = Material.valueOf(split[2]);
+                        } else {
+                            localMaterial = null;
+                        }
                         b.addConvBlocks(oldMaterial, newMaterial, convChance, localMaterial);
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Currently, it is required to specify `localMaterial` https://github.com/BentoBoxWorld/Greenhouses/blob/d990c7ac2322765839b96b96fabb2371d043f779/src/main/java/world/bentobox/greenhouses/managers/RecipeManager.java#L168

and setting `localMaterial` to `null` looks like it would allow conversion for any `localMaterial`: https://github.com/BentoBoxWorld/Greenhouses/blob/d990c7ac2322765839b96b96fabb2371d043f779/src/main/java/world/bentobox/greenhouses/greenhouse/BiomeRecipe.java#L216

However, there appears to be no current way to invoke this behavior. This PR allows omitting the third value of the colon-separated conversion specification, e.g. `50:TERRACOTTA:AIR` becomes `50:TERRACOTTA`, to relax the block adjacency restriction entirely.