### PR TITLE
Bugfix for trapdoors

### DIFF
--- a/src/main/java/world/bentobox/greenhouses/greenhouse/Roof.java
+++ b/src/main/java/world/bentobox/greenhouses/greenhouse/Roof.java
@@ -21,7 +21,6 @@ public class Roof extends MinMaxXZ {
     static {
         List<Material> r = Arrays.stream(Material.values())
                 .filter(Material::isBlock) // Blocks only, no items
-                .filter(m -> !m.name().contains("DOOR")) // No doors
                 .filter(m -> m.name().contains("TRAPDOOR") // All trapdoors
                         || m.name().contains("GLASS") // All glass blocks
                         || m.equals(Material.HOPPER) // Hoppers


### PR DESCRIPTION
When collecting valid roof materials, there is a filter that removes all materials with "DOOR" in the name.

This filter is both wrong (because it removes trapdoors as well) and unnecessary (because normal doors won't make it through the next filter - at least as long as no GLASS_DOOR is introduced ;) ). 