### PR TITLE
Fixed issue where greenhouses could not be created below y=0

### DIFF
--- a/src/main/java/world/bentobox/greenhouses/greenhouse/Walls.java
+++ b/src/main/java/world/bentobox/greenhouses/greenhouse/Walls.java
@@ -69,7 +69,7 @@ public class Walls extends MinMaxXZ {
         // The player is under the roof
         // Assume the player is inside the greenhouse they are trying to create
         final Location loc = roof.getLocation();
-        floor = getFloorY(roof.getHeight(), roof.getMinX(), roof.getMaxX(), roof.getMinZ(), roof.getMaxZ());
+        floor = getFloorY(roof.getHeight(), roof.getMinX(), roof.getMaxX(), roof.getMinZ(), roof.getMaxZ(), loc.getWorld().getMinHeight());
         // Now start with the player's x and z location
         WallFinder wf = new WallFinder();
         minX = loc.getBlockX();
@@ -85,7 +85,7 @@ public class Walls extends MinMaxXZ {
         minZ--;
         maxZ++;
         // Find the floor again, only looking within the walls
-        floor = getFloorY(roof.getHeight(), minX, maxX, minZ,maxZ);
+        floor = getFloorY(roof.getHeight(), minX, maxX, minZ,maxZ,loc.getWorld().getMinHeight());
         // Complete on main thread
         Bukkit.getScheduler().runTask(BentoBox.getInstance(), () -> r.complete(this));
         return this;
@@ -159,7 +159,7 @@ public class Walls extends MinMaxXZ {
         }
     }
 
-    int getFloorY(int y, int minX, int maxX, int minZ, int maxZ) {
+    int getFloorY(int y, int minX, int maxX, int minZ, int maxZ, int minY) {
         // Find the floor - defined as the last y under the roof where there are no wall blocks
         int wallBlockCount;
         do {
@@ -172,7 +172,7 @@ public class Walls extends MinMaxXZ {
                 }
             }
 
-        } while( y-- > -64 && wallBlockCount > 0);
+        } while( y-- > minY && wallBlockCount > 0);
         return y + 1;
 
     }

--- a/src/main/java/world/bentobox/greenhouses/greenhouse/Walls.java
+++ b/src/main/java/world/bentobox/greenhouses/greenhouse/Walls.java
@@ -172,7 +172,7 @@ public class Walls extends MinMaxXZ {
                 }
             }
 
-        } while( y-- > 0 && wallBlockCount > 0);
+        } while( y-- > -64 && wallBlockCount > 0);
         return y + 1;
 
     }

--- a/src/test/java/world/bentobox/greenhouses/greenhouse/WallsTest.java
+++ b/src/test/java/world/bentobox/greenhouses/greenhouse/WallsTest.java
@@ -91,7 +91,7 @@ public class WallsTest {
     @Test
     public void testFindWalls() {
         walls.findWalls(r, roof);
-        assertEquals("Walls [minX=-2, maxX=11, minZ=-2, maxZ=11, floor=0]", walls.toString());
+        assertEquals("Walls [minX=9, maxX=11, minZ=9, maxZ=11, floor=-64]", walls.toString());
     }
 
     /**
@@ -181,7 +181,7 @@ public class WallsTest {
      */
     @Test
     public void testGetFloorYZeroY() {
-        assertEquals(0, walls.getFloorY(10, 0, 1, 0, 1));
+        assertEquals(-64, walls.getFloorY(10, 0, 1, 0, 1));
     }
 
     /**

--- a/src/test/java/world/bentobox/greenhouses/greenhouse/WallsTest.java
+++ b/src/test/java/world/bentobox/greenhouses/greenhouse/WallsTest.java
@@ -91,7 +91,7 @@ public class WallsTest {
     @Test
     public void testFindWalls() {
         walls.findWalls(r, roof);
-        assertEquals("Walls [minX=9, maxX=11, minZ=9, maxZ=11, floor=-64]", walls.toString());
+        assertEquals("Walls [minX=-2, maxX=11, minZ=-2, maxZ=11, floor=0]", walls.toString());
     }
 
     /**
@@ -177,15 +177,15 @@ public class WallsTest {
     }
 
     /**
-     * Test method for {@link world.bentobox.greenhouses.greenhouse.Walls#getFloorY(int, int, int, int, int)}.
+     * Test method for {@link world.bentobox.greenhouses.greenhouse.Walls#getFloorY(int, int, int, int, int, int)}.
      */
     @Test
     public void testGetFloorYZeroY() {
-        assertEquals(-64, walls.getFloorY(10, 0, 1, 0, 1));
+        assertEquals(-64, walls.getFloorY(10, 0, 1, 0, 1, -64));
     }
 
     /**
-     * Test method for {@link world.bentobox.greenhouses.greenhouse.Walls#getFloorY(int, int, int, int, int)}.
+     * Test method for {@link world.bentobox.greenhouses.greenhouse.Walls#getFloorY(int, int, int, int, int, int)}.
      */
     @Test
     public void testGetFloorY() {
@@ -193,7 +193,7 @@ public class WallsTest {
                 Material.GLASS, Material.GLASS,
                 Material.GLASS, Material.GLASS,
                 Material.AIR);
-        assertEquals(8, walls.getFloorY(10, 0, 1, 0, 1));
+        assertEquals(8, walls.getFloorY(10, 0, 1, 0, 1, -64));
     }
 
     /**


### PR DESCRIPTION
Fixed issue that has been occurring since world lower limit was lowered. 
Should be relatively simple, and tested in game to work, however I will admit I am confused why the minX and minZ only changed by 11 instead of 64 due to the extra height of the greenhouse in the "testFindWalls" test.

This is in reference to issue #94 