### PR TITLE
Fix glow lichen growth and mob limit overshoot (#127)

### DIFF
--- a/src/main/java/world/bentobox/greenhouses/greenhouse/BiomeRecipe.java
+++ b/src/main/java/world/bentobox/greenhouses/greenhouse/BiomeRecipe.java
@@ -74,7 +74,10 @@ public class BiomeRecipe implements Comparable<BiomeRecipe> {
         m.add(Material.SEA_PICKLE);
         m.add(Material.SEAGRASS);
         m.add(Material.KELP);
-        m.add(Material.GLOW_LICHEN);
+        // Note: GLOW_LICHEN is deliberately NOT classed as underwater-only. It can grow on
+        // exposed block faces on land as well as underwater, and placeLichen() handles both
+        // (including waterlogging). Listing it here would route it into the underwater plant
+        // tree and make canGrowOn() reject it on land - see issue #127.
         UNDERWATER_PLANTS = Collections.unmodifiableList(m);
     }
 

--- a/src/main/java/world/bentobox/greenhouses/managers/EcoSystemManager.java
+++ b/src/main/java/world/bentobox/greenhouses/managers/EcoSystemManager.java
@@ -170,7 +170,10 @@ public class EcoSystemManager {
         if (gh.getBiomeRecipe().getMaxMob() > -1 && sum >= gh.getBiomeRecipe().getMaxMob()) {
             return false;
         }
-        while (it.hasNext() && (sum == 0 || gh.getArea() / sum >= gh.getBiomeRecipe().getMobLimit())) {
+        while (it.hasNext()
+                // Enforce the absolute maxmobs cap on every iteration, not just before the loop (issue #127)
+                && (gh.getBiomeRecipe().getMaxMob() <= -1 || sum < gh.getBiomeRecipe().getMaxMob())
+                && (sum == 0 || gh.getArea() / sum >= gh.getBiomeRecipe().getMobLimit())) {
             // Spawn something if chance says so
             if (gh.getBiomeRecipe().spawnMob(it.next().block())) {
                 // Add a mob to the sum in the greenhouse

--- a/src/test/java/world/bentobox/greenhouses/greenhouse/BiomeRecipeTest.java
+++ b/src/test/java/world/bentobox/greenhouses/greenhouse/BiomeRecipeTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
 import java.util.Optional;
 
 import org.bukkit.Bukkit;
@@ -24,9 +25,11 @@ import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.Bisected.Half;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.GlowLichen;
 import org.bukkit.entity.Cat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -780,6 +783,37 @@ public class BiomeRecipeTest {
         when(block.getRelative(BlockFace.UP)).thenReturn(upperBlock);
         assertTrue(br.addPlants(Material.SUNFLOWER, 100, Material.GRASS_BLOCK));
         assertFalse(br.growPlant(new GrowthBlock(block, true), false, ibb));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.greenhouses.greenhouse.BiomeRecipe#growPlant(GrowthBlock, boolean, BoundingBox)}.
+     * Issue #127 - Glow Lichen must be able to grow on exposed (non-underwater) blocks such as stone.
+     * It used to be classed as an underwater-only plant, so it never grew on land.
+     */
+    @Test
+    public void testGrowPlantGlowLichenOnLand() {
+        when(block.getY()).thenReturn(10);
+        when(block.getType()).thenReturn(Material.AIR);
+        when(block.isEmpty()).thenReturn(true);
+        // Stone source block directly below the growth block
+        Block stone = mock(Block.class);
+        when(stone.getType()).thenReturn(Material.STONE);
+        when(block.getRelative(BlockFace.DOWN)).thenReturn(stone);
+        // An exposed air face next to the stone for the lichen to attach to
+        Block face = mock(Block.class);
+        when(face.getType()).thenReturn(Material.AIR);
+        GlowLichen gl = mock(GlowLichen.class);
+        when(gl.getAllowedFaces()).thenReturn(EnumSet.allOf(BlockFace.class));
+        when(face.getBlockData()).thenReturn(gl);
+        BlockState state = mock(BlockState.class);
+        when(face.getState()).thenReturn(state);
+        when(stone.getRelative(any())).thenReturn(face);
+
+        assertTrue(br.addPlants(Material.GLOW_LICHEN, 100, Material.STONE));
+        assertTrue(br.growPlant(new GrowthBlock(block, true), false, ibb));
+        verify(face).setType(Material.GLOW_LICHEN);
+        // The face opposite to the chosen direction is lit up
+        verify(gl).setFace(BlockFace.UP, true);
     }
 
     /**

--- a/src/test/java/world/bentobox/greenhouses/managers/EcoSystemManagerTest.java
+++ b/src/test/java/world/bentobox/greenhouses/managers/EcoSystemManagerTest.java
@@ -8,6 +8,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -287,6 +289,24 @@ public class EcoSystemManagerTest {
         when(recipe.getMaxMob()).thenReturn(10);
         when(recipe.spawnMob(any())).thenReturn(true);
         assertTrue(eco.addMobs(gh));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.greenhouses.managers.EcoSystemManager#addMobs(Greenhouse)}.
+     * Issue #127 - the absolute maxmobs cap must be enforced on every spawn iteration, not only
+     * before the loop. The greenhouse area is 16 and the mob limit (density) is set to 1, so density
+     * alone would allow up to 16 mobs. maxmobs is 3, so exactly 3 mobs should spawn.
+     */
+    @Test
+    public void testAddMobsRespectsMaxMobLimit() {
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+        when(recipe.noMobs()).thenReturn(false);
+        when(recipe.getMaxMob()).thenReturn(3);
+        when(recipe.getMobLimit()).thenReturn(1);
+        when(recipe.spawnMob(any())).thenReturn(true);
+        assertTrue(eco.addMobs(gh));
+        // Without the fix the loop ignores maxMob and keeps spawning until density stops
+        verify(recipe, times(3)).spawnMob(any());
     }
 
 }


### PR DESCRIPTION
Fixes #127.

Two distinct bugs were reported. Both are addressed here.

## 1. Glow Lichen never grows on land
`GLOW_LICHEN` was hard-coded into the `UNDERWATER_PLANTS` list in `BiomeRecipe`. This had two combined effects:

- `addPlants()` routed it into the `underwaterPlants` probability tree, so it was only ever *selected* during underwater growth (i.e. for a water block sitting on a solid block).
- `canGrowOn()` then rejected it whenever the growth block was not `WATER`.

Net result: lichen could only appear where water sat directly above the target block, never on the exposed stone players configured (`GLOW_LICHEN: 10:STONE`). The irony is that `placeLichen()` already handles **both** the air-face and waterlogged cases correctly — it just never got the chance to run on land.

**Fix:** removed `GLOW_LICHEN` from `UNDERWATER_PLANTS` so it grows as a normal land plant.

## 2. `maxmobs` cap exceeded
`EcoSystemManager.addMobs()` checked the absolute `maxMob` cap only **once, before** the spawn loop. The `while` loop condition only enforced the per-area density (`mobLimit`), so starting from an empty greenhouse it kept spawning until `area / sum < mobLimit`, blowing past `maxmobs`. For the reported Plains example (`moblimit: 3`, `maxmobs: 3`, 18-block area) this allowed up to 6 mobs.

**Fix:** added the `maxMob` guard to the loop condition so the cap is enforced on every iteration.

> Note: the reporter's bee observation (bees in hives not being counted) is a separate, known limitation of counting via `world.getEntities()` and is intentionally left out of scope.

## Tests
- `BiomeRecipeTest.testGrowPlantGlowLichenOnLand` — lichen attaches to an exposed stone face on land.
- `EcoSystemManagerTest.testAddMobsRespectsMaxMobLimit` — spawning stops at the `maxmobs` cap even when density would allow more.

Full suite: 172 tests, 0 failures (JDK 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)