### PR TITLE
Add Modrinth publish workflow

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -90,6 +90,7 @@ jobs:
             1.21.11
             26.1
             26.1.1
+            26.1.2
 
           # Path to the built JAR — Maven produces Greenhouses-<version>.jar in target/
           # Note: glob patterns are not supported; use the release tag directly.

--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -1,0 +1,96 @@
+name: Publish to Modrinth
+
+# Triggers when you publish a GitHub Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. 1.9.5)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      # 1. Check out the repository at the release tag
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2. Set up Java 21 (required by Greenhouses' build)
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # 3. Cache Maven dependencies to speed up builds
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      # 4. Build the JAR
+      #    GIT_BRANCH=origin/master activates the Maven 'master' profile which
+      #    sets revision=${build.version} (no -SNAPSHOT suffix) and clears
+      #    build.number, producing a clean Greenhouses-<version>.jar.
+      - name: Build with Maven
+        run: mvn -B clean package -DskipTests
+        env:
+          GIT_BRANCH: origin/master
+
+      # 5. Upload the JAR to Modrinth
+      #
+      #    Prerequisites — add these secrets in your GitHub repo settings
+      #    (Settings → Secrets and variables → Actions):
+      #
+      #      MODRINTH_TOKEN      — personal access token from https://modrinth.com/settings/pats
+      #                            (scope: "Create versions")
+      #      MODRINTH_PROJECT_ID — your Modrinth project ID for Greenhouses, visible on the
+      #                            project page under the three-dot menu ("Copy ID")
+      #
+      - name: Publish to Modrinth
+        uses: cloudnode-pro/modrinth-publish@0be4916ad5f081d936eb5615aa35ce3f0949979c # v2
+        with:
+          token: ${{ secrets.MODRINTH_TOKEN }}
+          project: ${{ secrets.MODRINTH_PROJECT_ID }}
+
+          # Use the release tag, or the manually supplied tag when triggered via workflow_dispatch
+          version: ${{ github.event.release.tag_name || inputs.tag }}
+
+          # Use the GitHub release body as the changelog (empty when run manually)
+          changelog: ${{ github.event.release.body }}
+
+          # Release channel — auto-detected from version string:
+          #   *-alpha → alpha, *-beta → beta, anything else → release
+          # Override here if needed: release | beta | alpha
+          # channel: release
+
+          # Greenhouses is a Paper addon
+          loaders: |-
+            paper
+            purpur
+
+          # Minecraft versions this release supports.
+          # Update this list when you start supporting newer or older MC versions.
+          game-versions: |-
+            1.21.5
+            1.21.6
+            1.21.7
+            1.21.8
+            1.21.9
+            1.21.10
+            1.21.11
+            26.1
+            26.1.1
+
+          # Path to the built JAR — Maven produces Greenhouses-<version>.jar in target/
+          # Note: glob patterns are not supported; use the release tag directly.
+          files: target/Greenhouses-${{ github.event.release.tag_name || inputs.tag }}.jar

--- a/release-notes-1.9.5.md
+++ b/release-notes-1.9.5.md
@@ -1,0 +1,33 @@
+## New in this release
+
+This is a bug-fix release focused on plant growth and the greenhouse GUI.
+
+* 🔡 **GUI colour bleed fixed** — the Nether recipe entry used a red colour code that was never reset, turning the rest of the recipe panel text red. Tall/double plants (sunflowers, lilacs, rose bushes, etc.) now also correctly place their upper half instead of just the bottom block. [[PR #130](https://github.com/BentoBoxWorld/Greenhouses/pull/130)]
+* **Glow Lichen now grows on land** — it was treated as an underwater-only plant, so it would never appear on exposed blocks such as stone. It now attaches to land blocks as configured (e.g. `GLOW_LICHEN: 10:STONE`). [[PR #131](https://github.com/BentoBoxWorld/Greenhouses/pull/131)] Fixes [#127](https://github.com/BentoBoxWorld/Greenhouses/issues/127)
+* **`maxmobs` limit is now enforced** — mob spawning only checked the absolute `maxmobs` cap once before spawning, so greenhouses could overshoot the configured maximum. The cap is now honoured on every spawn. [[PR #131](https://github.com/BentoBoxWorld/Greenhouses/pull/131)] Fixes [#127](https://github.com/BentoBoxWorld/Greenhouses/issues/127)
+
+## Compatibility
+
+✔️ BentoBox API 2.7.1
+✔️ Paper Minecraft 1.21.5 - 26.1.x
+✔️ Java 21
+
+## Upgrading
+
+1. Take backups of your server, for safety.
+2. Download this jar and put it in your addons folder — delete the old one.
+3. Restart the server.
+4. You should be good to go!
+
+> 🔡 **Locale note:** the English (`en-US.yml`) locale strings for the recipe panel were updated. If you maintain customised locale files, re-check the affected keys.
+
+### Legend
+
+- 🔡 locale files may need to be regenerated or updated.
+
+## What's Changed
+
+* 🔡 Fix color bleed and double-plant bounding box (Stage 1) by @tastybento in https://github.com/BentoBoxWorld/Greenhouses/pull/130
+* Fix glow lichen growth and mob limit overshoot (#127) by @tastybento in https://github.com/BentoBoxWorld/Greenhouses/pull/131
+
+**Full Changelog**: https://github.com/BentoBoxWorld/Greenhouses/compare/1.9.4...1.9.5


### PR DESCRIPTION
Adds a `Publish to Modrinth` GitHub Actions workflow, bringing Greenhouses in line with AOneBlock, Level, Boxed, Border and Challenges.

## What it does
- Triggers on **Release → published**, with a `workflow_dispatch` fallback that takes a tag input.
- Builds with `GIT_BRANCH=origin/master` to activate the Maven `master` profile, producing a clean `Greenhouses-<version>.jar` (no `-SNAPSHOT`/`-LOCAL` suffix).
- Uploads the jar via [`cloudnode-pro/modrinth-publish`](https://github.com/cloudnode-pro/modrinth-publish) (pinned to the v2 commit SHA) for the `paper`/`purpur` loaders across MC **1.21.5 – 26.1.x**.

## Required secrets
Before the first publish, add these in **Settings → Secrets and variables → Actions**:
- `MODRINTH_TOKEN` — PAT from https://modrinth.com/settings/pats (scope: *Create versions*)
- `MODRINTH_PROJECT_ID` — the Greenhouses Modrinth project ID

Once merged, future published releases will auto-publish to Modrinth; existing releases can be pushed manually via *Run workflow*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)